### PR TITLE
Make Haskell libraries using souffle self-contained

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,7 @@ result
 result-*
 .history
 cbits/*.o
+# next line contains copied files from Souffle repo, used to create self-contained analysis
+cbits/souffle/*
+!cbits/souffle/.keep
 upload-docs.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cbits/souffle"]
+	path = cbits/souffle
+	url = git@github.com:souffle-lang/souffle.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "cbits/souffle"]
-	path = cbits/souffle
+[submodule "souffle"]
+	path = souffle
 	url = git@github.com:souffle-lang/souffle.git

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,3 +1,25 @@
+import Distribution.Verbosity
 import Distribution.Simple
-main = defaultMain
+import Distribution.Simple.Setup
+import Distribution.Simple.Utils
+import System.Directory (doesFileExist)
+
+prepareBuild :: Verbosity -> IO ()
+prepareBuild verbosity = do
+  ok <- doesFileExist "cbits/souffle/LICENSE"
+  if ok 
+    -- Nix and future versions of Stack automatically update the submodules,
+    -- so updating them is not necessary.
+    -- More-over, they fail if finding a .git folder,
+    -- hence avoiding invocations of git is necessary.
+    then pure ()
+    -- Stack/Cabal based builds currently require updating the submodules
+    else rawSystemExit verbosity "bash" ["prepare_submodule.sh"]
+
+main = defaultMainWithHooks simpleUserHooks
+  { preBuild = \args buildFlags -> do
+      let verbosity = fromFlagOrDefault normal $ buildVerbosity buildFlags
+      prepareBuild verbosity
+      preBuild simpleUserHooks args buildFlags
+  }
 

--- a/cbits/souffle.cpp
+++ b/cbits/souffle.cpp
@@ -1,4 +1,4 @@
-#include "souffle/SouffleInterface.h"
+#include "souffle/src/SouffleInterface.h"
 #include "souffle.h"
 
 

--- a/cbits/souffle.cpp
+++ b/cbits/souffle.cpp
@@ -1,4 +1,4 @@
-#include "souffle/src/SouffleInterface.h"
+#include "souffle/SouffleInterface.h"
 #include "souffle.h"
 
 

--- a/package.yaml
+++ b/package.yaml
@@ -70,6 +70,9 @@ cpp-options:
 include-dirs:
   - cbits
 
+install-includes:
+  - cbits/souffle/**/*.h
+
 library:
   source-dirs:        lib
   cxx-sources:        cbits/*.cpp

--- a/package.yaml
+++ b/package.yaml
@@ -15,6 +15,7 @@ extra-source-files:
   - LICENSE
   - cbits/souffle/LICENSE
   - cbits/souffle/**/*.h
+  - prepare_submodule.sh
 
 build-type: Custom
 custom-setup:

--- a/package.yaml
+++ b/package.yaml
@@ -13,7 +13,7 @@ extra-source-files:
   - README.md
   - CHANGELOG.md
   - LICENSE
-  - cbits/souffle/LICENSE
+  - souffle/LICENSE
   - cbits/souffle/**/*.h
   - prepare_submodule.sh
 
@@ -69,9 +69,39 @@ cpp-options:
 
 include-dirs:
   - cbits
+  - cbits/souffle
 
 install-includes:
-  - cbits/souffle/**/*.h
+  - souffle/CompiledSouffle.h
+  - souffle/Brie.h
+  - souffle/CompiledIndexUtils.h
+  - souffle/CompiledRecord.h
+  - souffle/CompiledRelation.h
+  - souffle/CompiledTuple.h
+  - souffle/IODirectives.h
+  - souffle/ParallelUtils.h
+  - souffle/IOSystem.h
+  - souffle/RamTypes.h
+  - souffle/SignalHandler.h
+  - souffle/SouffleInterface.h
+  - souffle/SymbolTable.h
+  - souffle/Util.h
+  - souffle/WriteStream.h
+  - BTree.h
+  - EquivalenceRelation.h
+  - LambdaBTree.h
+  - UnionFind.h
+  - Util.h
+  - PiggyList.h
+  - ParallelUtils.h
+  - IterUtils.h
+  - Table.h
+  - ReadStream.h
+  - ReadStreamCSV.h
+  - ReadStreamSQLite.h
+  - IODirectives.h
+  - RamTypes.h
+  - SymbolTable.h
 
 library:
   source-dirs:        lib

--- a/package.yaml
+++ b/package.yaml
@@ -13,7 +13,15 @@ extra-source-files:
   - README.md
   - CHANGELOG.md
   - LICENSE
-  - cbits/*.h
+  - cbits/souffle/LICENSE
+  - cbits/souffle/**/*.h
+
+build-type: Custom
+custom-setup:
+  dependencies:
+    - Cabal >= 3.0
+    - base >= 4.12 && < 5
+    - directory >= 1.3.3 && < 2
 
 dependencies:
   - base >= 4.12 && < 5
@@ -51,8 +59,15 @@ ghc-options:
   - -fno-show-valid-hole-fits
   - -fno-sort-valid-hole-fits
 
+cxx-options:
+  - -std=c++17
+
+# TODO remove once TH module is removed
 cpp-options:
   - -std=c++17
+
+include-dirs:
+  - cbits
 
 library:
   source-dirs:        lib
@@ -75,5 +90,8 @@ tests:
     dependencies:
       - hspec >= 2.6.1 && < 3.0.0
       - souffle-haskell
+    cxx-options:
+      - -D__EMBEDDED_SOUFFLE__
+    # TODO remove once TH module is removed
     cpp-options:
       - -D__EMBEDDED_SOUFFLE__

--- a/prepare_submodule.sh
+++ b/prepare_submodule.sh
@@ -2,13 +2,20 @@
 
 set -eu
 
+function setup_souffle_headers() {
+    ls cbits/souffle | xargs rm -rf
+    cp -r souffle/src/* cbits/souffle
+}
+
 if [ -e .git ]; then
   git submodule update --init --recursive
+  setup_souffle_headers
   exit 0
 fi
 
 SOUFFLE_VERSION="1.7.1"
 curl https://github.com/souffle-lang/souffle/archive/${SOUFFLE_VERSION}.tar.gz -sL -o - | tar xz
-mv souffle-${SOUFFLE_VERSION} cbits/souffle
+mv souffle-${SOUFFLE_VERSION} souffle
+setup_souffle_headers
 exit 0
 

--- a/prepare_submodule.sh
+++ b/prepare_submodule.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eu
+
+if [ -e .git ]; then
+  git submodule update --init --recursive
+  exit 0
+fi
+
+SOUFFLE_VERSION="1.7.1"
+curl https://github.com/souffle-lang/souffle/archive/${SOUFFLE_VERSION}.tar.gz -L -o - | tar xz
+mv souffle-${SOUFFLE_VERSION} cbits/souffle
+exit 0
+

--- a/prepare_submodule.sh
+++ b/prepare_submodule.sh
@@ -8,7 +8,7 @@ if [ -e .git ]; then
 fi
 
 SOUFFLE_VERSION="1.7.1"
-curl https://github.com/souffle-lang/souffle/archive/${SOUFFLE_VERSION}.tar.gz -L -o - | tar xz
+curl https://github.com/souffle-lang/souffle/archive/${SOUFFLE_VERSION}.tar.gz -sL -o - | tar xz
 mv souffle-${SOUFFLE_VERSION} cbits/souffle
 exit 0
 


### PR DESCRIPTION
This will no longer require every package that depends on a Haskell library with souffle code to need the souffle C++ headers.