### PR TITLE
Fixing TypeFamilyDependencies error and some warnings

### DIFF
--- a/lib/Language/Souffle/Experimental.hs
+++ b/lib/Language/Souffle/Experimental.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE UndecidableInstances, UndecidableSuperClasses, FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, DerivingVia, ScopedTypeVariables #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 {-| This module provides an experimental DSL for generating Souffle Datalog code,

--- a/souffle-haskell.cabal
+++ b/souffle-haskell.cabal
@@ -83,7 +83,7 @@ library
   hs-source-dirs:
       lib
   default-extensions: OverloadedStrings LambdaCase ScopedTypeVariables
-  ghc-options: -Wall -Weverything -Wno-safe -Wno-unsafe -Wno-implicit-prelude -Wno-missed-specializations -Wno-all-missed-specializations -Wno-missing-import-lists -Wno-type-defaults -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-deriving-strategies -optP-Wno-nonportable-include-path -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits
+  ghc-options: -Wall -Weverything -Wno-safe -Wno-unsafe -Wno-implicit-prelude -Wno-missed-specializations -Wno-all-missed-specializations -Wno-missing-import-lists -Wno-type-defaults -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-deriving-strategies -optP-Wno-nonportable-include-path -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits -Wno-prepositive-qualified-module -Wno-missing-safe-haskell-mode
   cxx-options: -std=c++17 -Wall
   include-dirs:
       cbits


### PR DESCRIPTION
Adding

> LANGUAGE TypeFamilyDependencies

to `Language/Souffle/Experimental.hs`

to resolve error:

```
lib/Language/Souffle/Experimental.hs:1081:1: error:
    • Illegal result type variable c for ‘++’
        Enable TypeFamilyDependencies to allow result variable names
    • In the type family declaration for ‘++’
```

and

> -Wno-prepositive-qualified-module -Wno-missing-safe-haskell-mode

to ghc-options to reduce warnings.

System info:

```
lyndon@difference|~/code/souffle-haskell on lyndon/TypeFamilyDependencies-error
± ghc --version
The Glorious Glasgow Haskell Compilation System, version 8.10.2
lyndon@difference|~/code/souffle-haskell on lyndon/TypeFamilyDependencies-error
± uname -a
Darwin difference.local 18.7.0 Darwin Kernel Version 18.7.0: Mon Aug 31 20:53:32 PDT 2020; root:xnu-4903.278.44~1/RELEASE_X86_64 x86_64
```

Previous output when building looks like so:

```

lib/Language/Souffle/Internal/Bindings.hs:1:1: warning: [-Wmissing-safe-haskell-mode]
    Language.Souffle.Internal.Bindings is missing Safe Haskell mode
  |
1 |
  | ^
[2 of 9] Compiling Language.Souffle.Internal

lib/Language/Souffle/Internal.hs:1:1: warning: [-Wmissing-safe-haskell-mode]
    Language.Souffle.Internal is missing Safe Haskell mode
  |
1 |
  | ^

lib/Language/Souffle/Internal.hs:48:8: warning: [-Wprepositive-qualified-module]
    Found ‘qualified’ in prepositive position
    Suggested fix: place  ‘qualified’ after the module name instead.
   |
48 | import qualified Language.Souffle.Internal.Bindings as Bindings
   |        ^^^^^^^^^
[3 of 9] Compiling Language.Souffle.Internal.Constraints

lib/Language/Souffle/Internal/Constraints.hs:1:1: warning: [-Wmissing-safe-haskell-mode]
    Language.Souffle.Internal.Constraints is missing Safe Haskell mode
  |
1 | {-# LANGUAGE TypeFamilies, DataKinds, TypeOperators, UndecidableInstances #-}
  | ^

lib/Language/Souffle/Internal/Constraints.hs:15:8: warning: [-Wprepositive-qualified-module]
    Found ‘qualified’ in prepositive position
    Suggested fix: place  ‘qualified’ after the module name instead.
   |
15 | import qualified Data.Text as T
   |        ^^^^^^^^^

lib/Language/Souffle/Internal/Constraints.hs:16:8: warning: [-Wprepositive-qualified-module]
    Found ‘qualified’ in prepositive position
    Suggested fix: place  ‘qualified’ after the module name instead.
   |
16 | import qualified Data.Text.Lazy as TL
   |        ^^^^^^^^^
[4 of 9] Compiling Language.Souffle.Marshal

lib/Language/Souffle/Marshal.hs:1:1: warning: [-Wmissing-safe-haskell-mode]
    Language.Souffle.Marshal is missing Safe Haskell mode
  |
1 | {-# OPTIONS_GHC -Wno-redundant-constraints #-}
  | ^

lib/Language/Souffle/Marshal.hs:18:8: warning: [-Wprepositive-qualified-module]
    Found ‘qualified’ in prepositive position
    Suggested fix: place  ‘qualified’ after the module name instead.
   |
18 | import qualified Data.Text as T
   |        ^^^^^^^^^

lib/Language/Souffle/Marshal.hs:19:8: warning: [-Wprepositive-qualified-module]
    Found ‘qualified’ in prepositive position
    Suggested fix: place  ‘qualified’ after the module name instead.
   |
19 | import qualified Data.Text.Lazy as TL
   |        ^^^^^^^^^

lib/Language/Souffle/Marshal.hs:20:8: warning: [-Wprepositive-qualified-module]
    Found ‘qualified’ in prepositive position
    Suggested fix: place  ‘qualified’ after the module name instead.
   |
20 | import qualified Language.Souffle.Internal.Constraints as C
   |        ^^^^^^^^^
[5 of 9] Compiling Language.Souffle.Class

lib/Language/Souffle/Class.hs:1:1: warning: [-Wmissing-safe-haskell-mode]
    Language.Souffle.Class is missing Safe Haskell mode
  |
1 | {-# LANGUAGE DataKinds, UndecidableInstances, FlexibleContexts #-}
  | ^

lib/Language/Souffle/Class.hs:38:8: warning: [-Wprepositive-qualified-module]
    Found ‘qualified’ in prepositive position
    Suggested fix: place  ‘qualified’ after the module name instead.
   |
38 | import qualified Language.Souffle.Marshal as Marshal
   |        ^^^^^^^^^
[6 of 9] Compiling Language.Souffle.Interpreted

lib/Language/Souffle/Interpreted.hs:1:1: warning: [-Wmissing-safe-haskell-mode]
    Language.Souffle.Interpreted is missing Safe Haskell mode
  |
1 | {-# OPTIONS_GHC -Wno-redundant-constraints #-}
  | ^

lib/Language/Souffle/Interpreted.hs:38:8: warning: [-Wcompat-unqualified-imports]
    To ensure compatibility with future core libraries changes
    imports to Data.List should be
    either qualified or have an explicit import list.
   |
38 | import Data.List hiding (init)
   |        ^^^^^^^^^

lib/Language/Souffle/Interpreted.hs:42:8: warning: [-Wprepositive-qualified-module]
    Found ‘qualified’ in prepositive position
    Suggested fix: place  ‘qualified’ after the module name instead.
   |
42 | import qualified Data.Array as A
   |        ^^^^^^^^^

lib/Language/Souffle/Interpreted.hs:43:8: warning: [-Wprepositive-qualified-module]
    Found ‘qualified’ in prepositive position
    Suggested fix: place  ‘qualified’ after the module name instead.
   |
43 | import qualified Data.Text as T
   |        ^^^^^^^^^

lib/Language/Souffle/Interpreted.hs:44:8: warning: [-Wprepositive-qualified-module]
    Found ‘qualified’ in prepositive position
    Suggested fix: place  ‘qualified’ after the module name instead.
   |
44 | import qualified Data.Vector as V
   |        ^^^^^^^^^
[7 of 9] Compiling Language.Souffle.Experimental

lib/Language/Souffle/Experimental.hs:1081:1: error:
    • Illegal result type variable c for ‘++’
        Enable TypeFamilyDependencies to allow result variable names
    • In the type family declaration for ‘++’
```