### PR TITLE
Proof of concept for higher-order DSL API

### DIFF
--- a/tests/Test/Language/Souffle/ExperimentalSpec.hs
+++ b/tests/Test/Language/Souffle/ExperimentalSpec.hs
@@ -235,10 +235,9 @@ spec = describe "Souffle DSL" $ parallel $ do
     it "can render a relation with a single rule" $ do
       let prog = do
             Predicate edge <- predicateFor @Edge
-            Predicate reachable <- predicateFor @Reachable
-            a <- var "a"
-            b <- var "b"
-            reachable(a, b) |- edge(a, b)
+            reachable'@(Predicate reachable) <- predicateFor @Reachable
+            reachable' ||- \ a b -> edge(a, b)
+            reachable' ||- \ a b -> reachable(a, b)
       prog ==> [text|
         .decl edge(t1: symbol, t2: symbol)
         .input edge


### PR DESCRIPTION
# This pull request is not ready for merging, but I want to use the Github PR interface to discuss it.

I just saw your Berlin FP Meetup talk, and I noticed that in the DSL you require variables to be explicitly created by the user. I think a much nicer API is if you allow `|-` to allow functions on the right-hand side. In this PR, I illustrate how you can do that, and also use code comments to show the things that are still TODO in my code.

The money shot is this:

```
            reachable' |- \ a b -> edge(a, b)
            reachable' |- \ a b -> reachable(a, b)
```

The fact that you need a slightly different `reachable'` and `reachable` on the two sides is something that I think you will be able to fix.
