### PR TITLE
Add role annotations

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -71,6 +71,10 @@
     name: Use camelCase
     within:
       - Language.Souffle.Experimental
+- ignore:
+    name: Use newtype instead of data
+    within:
+      - Language.Souffle.Compiled
 
 
 # Define some custom infix operators

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The CHANGELOG is available on [Github](https://github.com/luc-tielen/souffle-has
 - Fix GHC 8.10 specific warnings and compile error.
 - Support Semigroup and Monoid instances for composing Souffle actions in
   other ways.
+- Add role annotations to handle types to avoid using `coerce` to change
+  the type of a Souffle handle.
 
 ## [2.0.1] - 2020-09-05
 

--- a/lib/Language/Souffle/Compiled.hs
+++ b/lib/Language/Souffle/Compiled.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
-{-# LANGUAGE FlexibleInstances, TypeFamilies, DerivingVia, InstanceSigs, BangPatterns #-}
+{-# LANGUAGE FlexibleInstances, TypeFamilies, DerivingVia, InstanceSigs #-}
+{-# LANGUAGE BangPatterns, RoleAnnotations #-}
 
 -- | This module provides an implementation for the typeclasses defined in
 --   "Language.Souffle.Class".
@@ -42,11 +43,11 @@ import Language.Souffle.Class
 import qualified Language.Souffle.Internal as Internal
 import Language.Souffle.Marshal
 
-
 -- | A datatype representing a handle to a datalog program.
 --   The type parameter is used for keeping track of which program
 --   type the handle belongs to for additional type safety.
-newtype Handle prog = Handle (ForeignPtr Internal.Souffle)
+data Handle prog = Handle (ForeignPtr Internal.Souffle)
+type role Handle nominal
 
 -- | A monad for executing Souffle-related actions in.
 newtype SouffleM a = SouffleM (IO a)

--- a/lib/Language/Souffle/Interpreted.hs
+++ b/lib/Language/Souffle/Interpreted.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
-{-# LANGUAGE FlexibleInstances, TypeFamilies, DerivingVia, InstanceSigs, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, TypeFamilies, DerivingVia, InstanceSigs #-}
+{-# LANGUAGE UndecidableInstances, RoleAnnotations #-}
 
 -- | This module provides an implementation for the `MonadSouffle` typeclass
 --   defined in "Language.Souffle.Class".
@@ -169,6 +170,7 @@ data Handle prog = Handle
   , stdoutResult :: IORef (Maybe T.Text)
   , stderrResult :: IORef (Maybe T.Text)
   }
+type role Handle nominal
 
 -- | The data needed for the interpreter is the path where the souffle
 --   executable can be found, and a template directory where the program


### PR DESCRIPTION
As pointed out by IcelandJack on Twitter, without the type roles it was
possible to use `coerce` a handle of type `Handle a` to `Handle b`. This
could lead to broken behavior but has been fixed by adding role
annotations.