### PR TITLE
fix for permission denied error during git submodule update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
           sudo swapoff -a
           sudo rm -f /swapfile
           sudo apt clean
-          docker rmi $(docker image ls -aq) || true
           df -h
 
       # In this step, this action saves a list of existing images, the cache is created without them in the post run.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # Workaround for 'No space left on device' error
+      - name: free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq) || true
+          df -h
+
       # In this step, this action saves a list of existing images, the cache is created without them in the post run.
       # It also restores the cache if it exists.
       - uses: jpribyl/action-docker-layer-caching@v0.1.1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "souffle"]
 	path = souffle
-	url = git@github.com:souffle-lang/souffle.git
+	url = https://github.com/souffle-lang/souffle


### PR DESCRIPTION
+ Use https url instead of git url for git submodule 
  to get around `Permission denied (public key)` error
+ Cleanup disk space in CI workflow to get around 
  `No space left on device` error