### PR TITLE
Add missing imports

### DIFF
--- a/lib/Language/Souffle/Compiled.hs
+++ b/lib/Language/Souffle/Compiled.hs
@@ -31,7 +31,7 @@ module Language.Souffle.Compiled
   ) where
 
 import Prelude hiding ( init )
-import Control.Monad.Except
+import Control.Monad ( when )
 import Control.Monad.State.Strict
 import Data.Foldable ( traverse_ )
 import Data.Functor.Identity
@@ -497,4 +497,3 @@ writeBytes bufVar relation fa = case estimateNumBytes (Proxy @a) of
         pure bufData'
   where objCount = length fa
 {-# INLINABLE writeBytes #-}
-

--- a/lib/Language/Souffle/Interpreted.hs
+++ b/lib/Language/Souffle/Interpreted.hs
@@ -35,6 +35,7 @@ import Data.Kind (Type, Constraint)
 
 import Control.DeepSeq (deepseq)
 import Control.Exception (ErrorCall(..), throwIO, bracket)
+import Control.Monad (forM, forM_, (<$!>))
 import Control.Monad.State.Strict
 import Data.IORef
 import Data.Foldable (traverse_)


### PR DESCRIPTION
This change fixes the following errors with ghc-9.6:

  lib/Language/Souffle/Interpreted.hs:305:9: error: [GHC-88464]
      Variable not in scope:
        forM_

  lib/Language/Souffle/Compiled.hs:214:3: error: [GHC-88464]
      Variable not in scope:
        when :: Bool -> CMarshalSlow () -> CMarshalSlow ()
      |
  214 |   when (byteCount + offset > totalByteCount) $ do